### PR TITLE
Check ERIC authorised token permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <!-- Dependency Versions -->
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-        <api-sdk-java.version>4.1.4</api-sdk-java.version>
+        <api-sdk-java.version>4.2.0</api-sdk-java.version>
         <structured-logging.version>1.9.3</structured-logging.version>
-        <api-sdk-manager-java-library.version>1.0.1</api-sdk-manager-java-library.version>
+        <api-sdk-manager-java-library.version>1.0.2</api-sdk-manager-java-library.version>
 
         <!-- JDK -->
         <source-level>1.8</source-level>

--- a/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
@@ -2,9 +2,6 @@ package uk.gov.companieshouse.api.util.security;
 
 import javax.servlet.http.HttpServletRequest;
 
-import uk.gov.companieshouse.api.util.security.EricConstants;
-import uk.gov.companieshouse.api.util.security.RequestUtils;
-
 public final class AuthorisationUtil {
     private AuthorisationUtil() {}
     
@@ -18,6 +15,10 @@ public final class AuthorisationUtil {
     
     public static String getAuthorisedKeyRoles(HttpServletRequest request) {
         return RequestUtils.getRequestHeader(request, EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+    }
+    
+    protected static String getAuthorisedTokenPermissions(HttpServletRequest request) {
+        return RequestUtils.getRequestHeader(request, EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS);
     }
     
     public static boolean hasInternalUserRole(HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/api/util/security/EricConstants.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/EricConstants.java
@@ -6,6 +6,7 @@ public final class EricConstants {
     public static final String ERIC_IDENTITY = "ERIC-Identity";
     public static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     public static final String ERIC_AUTHORISED_KEY_ROLES = "ERIC-Authorised-Key-Roles";
+    public static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS = "ERIC-Authorised-Token-Permissions";
 
     public static final String API_KEY_IDENTITY_TYPE = "key";
     public static final String INTERNAL_USER_ROLE = "*";

--- a/src/main/java/uk/gov/companieshouse/api/util/security/InvalidTokenPermissionException.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/InvalidTokenPermissionException.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.api.util.security;
+
+public class InvalidTokenPermissionException extends Exception {
+    private static final long serialVersionUID = -8911200210133036075L;
+    
+    private final String authorisedTokenPermissions;
+
+    public InvalidTokenPermissionException(String authorisedTokenPermissions) {
+        this.authorisedTokenPermissions = authorisedTokenPermissions;
+    }
+
+    public String getAuthorisedTokenPermissions() {
+        return authorisedTokenPermissions;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.api.util.security;
+
+public class Permission {
+
+    public enum Key {
+        /**
+         * Key for the user profile permissions permissions
+         */
+        USER_PROFILE("user_profile"),
+        /**
+         * Key for the user transactions permissions
+         */
+        USER_TRANSACTIONS("user_transactions"),
+        /**
+         * Key for the user follow permissions
+         */
+        USER_FOLLOWING("user_following"),
+        /**
+         * Key for the user application/api client permissions
+         */
+        USER_APPLICATIONS("user_applications"),
+        /**
+         * Key for the detailing the company number for any company level permissions
+         */
+        COMPANY_NUMBER("company_number"),
+        /**
+         * Key for the company auth code permissions
+         */
+        COMPANY_AUTH_CODE("company_auth_code"),
+        /**
+         * Key for company registered office address (ROA) permissions
+         */
+        COMPANY_ROA("company_roa"),
+        /**
+         * Key for company accounts (annual accounts filing) permissions
+         */
+        COMPANY_ACCOUNTS("company_accounts");
+
+        private String stringValue;
+
+        private Key(String permissionKey) {
+            stringValue = permissionKey;
+        }
+
+        @Override
+        public String toString() {
+            return stringValue;
+        }
+    }
+    
+    public static class Value {
+        /**
+         * Value for resource creation permissions
+         */
+        public static final String CREATE = "create";
+        /**
+         * Value for resource reading permissions
+         */
+        public static final String READ = "read";
+        /**
+         * Value for resource updating permissions
+         */
+        public static final String UPDATE = "update";
+        /**
+         * Value for resource deletion permissions
+         */
+        public static final String DELETE = "delete";
+        
+        private Value() {
+            // Hide implicit public constructor
+        }
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.api.util.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Reads and stores the authorised ERIC token permissions from a request and
+ * provides a method to check them individually
+ */
+public class TokenPermissions {
+
+    final String authorisedTokenPermissions;
+    Map<String, List<String>> permissions;
+
+    public TokenPermissions(HttpServletRequest request) {
+        authorisedTokenPermissions = AuthorisationUtil.getAuthorisedTokenPermissions(request);
+    }
+
+    /**
+     * Check if the current key/value permission pair exists
+     * 
+     * @param key   The permission key
+     * @param value The permission value
+     * @return True if the key/value permission pair is present in the list of
+     *         authorised token permission
+     */
+    public boolean hasPermission(Permission.Key key, String value) {
+        if (permissions == null) {
+            permissions = readTokenPermissions(authorisedTokenPermissions);
+        }
+
+        return permissions.getOrDefault(key.toString(), Collections.emptyList()).contains(value);
+    }
+
+    /**
+     * The ERIC token permission is of the format: 
+     *       "key1=valueA key2=valueB key3=valueC,valueD,valueE"
+     * i.e. space separated key value pairs which themselves are separated by "=".
+     * values can also be split on a comma so we end up with an array of values per key
+     * 
+     * The example value above becomes:
+     *       "key1" : ["valueA"],
+     *       "key2" : ["valueB"],
+     *       "key3" : ["valueC", "valueD", "valueE"]
+     * 
+     * @param authorisedTokenPermissions
+     * @return
+     */
+    private Map<String, List<String>> readTokenPermissions(String authorisedTokenPermissions) {
+        if (StringUtils.isBlank(authorisedTokenPermissions)) {
+            return Collections.emptyMap();
+        }
+        return Stream.of(authorisedTokenPermissions.trim().split(" "))
+                .map(pair -> pair.split("="))
+                .filter(s -> s.length == 2) // Ignore invalid key/value pairs
+                .collect(Collectors.toMap(s -> s[0], s -> Arrays.asList(s[1].split(","))));
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.api.util.security;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -12,12 +13,16 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringUtils;
 
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
 /**
  * Reads and stores the authorised ERIC token permissions from a request and
  * provides a method to check them individually
  */
 public class TokenPermissions {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(TokenPermissions.class));
     private static final Pattern PERMISSION_LIST_PATTERN = Pattern.compile("^\\w+=\\w+(,\\w+)*( \\w+=\\w+(,\\w+)*)*$");
 
     final String authorisedTokenPermissions;
@@ -42,7 +47,11 @@ public class TokenPermissions {
      */
     public boolean hasPermission(Permission.Key key, String value) {
         if (permissions == null) {
-            permissions = readTokenPermissions();
+            permissions = readTokenPermissions(authorisedTokenPermissions);
+            Map<String, Object> logData = new HashMap<>();
+            logData.put("ERIC authorised token permission header", authorisedTokenPermissions);
+            logData.put("Token permissions", permissions);
+            LOGGER.debug("Parsed ERIC token permissions", logData);
         }
 
         return permissions.getOrDefault(key.toString(), Collections.emptyList()).contains(value);

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.api.util.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TokenPermissionsTest {
+    
+    private static final String AUTHORISED_TOKEN_PERMISSIONS = "user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete";
+
+    TokenPermissions permissions;
+
+    @Test
+    void hasPermissionKeyAndValue() {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    }
+
+    @Test
+    void hasPermissionKeyNotValue() {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
+        assertFalse(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, "missing"));
+    }
+
+    @Test
+    void hasPermissionNoKey() {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_ROA, Permission.Value.DELETE));
+    }
+
+    @Test
+    void hasPermissionMissingHeader() {
+        setupPermissionHeader(null);
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    }
+    
+    @Test
+    void hasPermissionEmptyHeader() {
+        setupPermissionHeader("");
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    }
+    
+    @Test
+    void hasPermissionBlankHeader() {
+        setupPermissionHeader("   ");
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    }
+    
+    @Test
+    void hasPermissionInvalidPairRequestedKey() {
+        setupPermissionHeader("user_profile=read user_transactions= company_auth_code=read,update,delete");
+        assertFalse(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.DELETE));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
+    }
+    
+    @Test
+    void hasPermissionInvalidPairDifferentKey() {
+        setupPermissionHeader("user_profile=read user_transactions= company_auth_code=read,update,delete");
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
+    }
+    
+    private void setupPermissionHeader(String authorisedTokenPermissins) {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(authorisedTokenPermissins);
+
+        permissions = new TokenPermissions(request);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.api.util.security;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -16,55 +17,41 @@ public class TokenPermissionsTest {
     TokenPermissions permissions;
 
     @Test
-    void hasPermissionKeyAndValue() {
+    void hasPermissionKeyAndValue() throws InvalidTokenPermissionException {
         setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
     }
 
     @Test
-    void hasPermissionKeyNotValue() {
+    void hasPermissionKeyNotValue() throws InvalidTokenPermissionException {
         setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, "missing"));
     }
 
     @Test
-    void hasPermissionNoKey() {
+    void hasPermissionNoKey() throws InvalidTokenPermissionException {
         setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_ROA, Permission.Value.DELETE));
     }
 
     @Test
-    void hasPermissionMissingHeader() {
+    void hasPermissionMissingHeader() throws InvalidTokenPermissionException {
         setupPermissionHeader(null);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
     }
-    
+
     @Test
-    void hasPermissionEmptyHeader() {
-        setupPermissionHeader("");
-        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    void invalidTokenPermissions() {
+        assertThrows(InvalidTokenPermissionException.class, () -> setupPermissionHeader(
+                "user_profile=read user_transactions= company_auth_code=read,update,delete"));
     }
-    
+
     @Test
-    void hasPermissionBlankHeader() {
-        setupPermissionHeader("   ");
-        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
+    void invalidEmptyTokenPermissions() {
+        assertThrows(InvalidTokenPermissionException.class, () -> setupPermissionHeader(""));
     }
-    
-    @Test
-    void hasPermissionInvalidPairRequestedKey() {
-        setupPermissionHeader("user_profile=read user_transactions= company_auth_code=read,update,delete");
-        assertFalse(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.DELETE));
-        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
-    }
-    
-    @Test
-    void hasPermissionInvalidPairDifferentKey() {
-        setupPermissionHeader("user_profile=read user_transactions= company_auth_code=read,update,delete");
-        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
-    }
-    
-    private void setupPermissionHeader(String authorisedTokenPermissins) {
+
+    private void setupPermissionHeader(String authorisedTokenPermissins) throws InvalidTokenPermissionException {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(authorisedTokenPermissins);
 


### PR DESCRIPTION
New `TokenPermissions` class to store and check ERIC authorised token permissions from a request header
Public constants for keys (enum) and values (Strings)

FA-583