### PR TITLE
Add unit test for passing a null value

### DIFF
--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -71,6 +71,12 @@ public class TokenPermissionsTest {
         setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_ROA, Permission.Value.DELETE));
     }
+    
+    @Test
+    void hasPermissionNullValue() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_NUMBER, null));
+    }
 
     @Test
     void hasPermissionMissingHeader() throws InvalidTokenPermissionException {


### PR DESCRIPTION
A null value sent to the `hasPermission` method should always return false. Add unit test to cover this