### PR TITLE
Create token permission interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/interceptor/InternalUserInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/InternalUserInterceptor.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
-import uk.gov.companieshouse.api.util.security.EricConstants;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -43,7 +43,7 @@ public class InternalUserInterceptor extends HandlerInterceptorAdapter {
         }
 
         final String identityType = AuthorisationUtil.getAuthorisedIdentityType(request);
-        if ( ! StringUtils.equals(identityType, EricConstants.API_KEY_IDENTITY_TYPE)) {
+        if ( ! StringUtils.equals(identityType, SecurityConstants.API_KEY_IDENTITY_TYPE)) {
             LOG.debugRequest(request, "invalid identity type [" + identityType + "]", null);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return false;

--- a/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
@@ -60,4 +60,28 @@ public class TokenPermissionsInterceptor extends HandlerInterceptorAdapter {
         // cleanup request to ensure it is never leaked into another request
         request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, null);
     }
+
+    /**
+     * Set the feature flag: if on (true) this interceptor will create a token
+     * permissions object which will check the relevant eric header to authorise via
+     * token permissions. If off (false), the object stored in the session will only
+     * check the header for the company number permission and authorise any other
+     * 
+     * @param enable
+     */
+    public void setEnableTokenPermission(boolean enable) {
+        enableTokenPermissionAuth = enable;
+    }
+    
+    /**
+     * Read the feature flag: if on (true) this interceptor will create a token
+     * permissions object which will check the relevant eric header to authorise via
+     * token permissions. If off (false), the object stored in the session will only
+     * check the header for the company number permission and authorise any other
+     * 
+     * @return True if the feature flag is on. False if it is off
+     */
+    public boolean isEnableTokenPermission() {
+        return enableTokenPermissionAuth;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
@@ -1,0 +1,63 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Creates a TokenPermissions object and sets it into the request. 
+ * It can then be read by using {@link AuthorisationUtil.getTokenPermissions(request)}
+ */
+@Component
+public class TokenPermissionsInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(TokenPermissionsInterceptor.class));
+
+    @Value("${ENABLE_TOKEN_PERMISSION_AUTH:#{false}}")
+    boolean enableTokenPermissionAuth;
+    
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws InvalidTokenPermissionException {
+        Map<String, Object> loggedData = new HashMap<>();
+        loggedData.put("Feature flag ENABLE_TOKEN_PERMISSION_AUTH", enableTokenPermissionAuth);
+        LOGGER.debug("Create TokenPermissions and store it in request", loggedData);
+        final TokenPermissions tokenPermissions = new TokenPermissionsImpl(request);
+        if (enableTokenPermissionAuth) {
+            request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, tokenPermissions);
+        } else {
+            // We behave as if we had all permissions except for the company number
+            TokenPermissions tp = (k, v) -> {
+                if (k.equals(Permission.Key.COMPANY_NUMBER)) {
+                    return tokenPermissions.hasPermission(k, v);
+                } else {
+                    return true;
+                }
+            };
+            request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, tp);
+        }
+        return true;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+            ModelAndView modelAndView) throws Exception {
+        // cleanup request to ensure it is never leaked into another request
+        request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, null);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
@@ -28,6 +28,6 @@ public final class AuthorisationUtil {
     }
     
     public static Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
-        return Optional.ofNullable((TokenPermissions) request.getAttribute("token_permissions"));
+        return Optional.ofNullable((TokenPermissions) request.getAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.api.util.security;
 
+import java.util.Optional;
+
 import javax.servlet.http.HttpServletRequest;
 
 public final class AuthorisationUtil {
@@ -22,6 +24,10 @@ public final class AuthorisationUtil {
     }
     
     public static boolean hasInternalUserRole(HttpServletRequest request) {
-        return EricConstants.INTERNAL_USER_ROLE.equals(getAuthorisedKeyRoles(request));
+        return SecurityConstants.INTERNAL_USER_ROLE.equals(getAuthorisedKeyRoles(request));
+    }
+    
+    public static Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return Optional.ofNullable((TokenPermissions) request.getAttribute("token_permissions"));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/api/util/security/EricConstants.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/EricConstants.java
@@ -7,7 +7,4 @@ public final class EricConstants {
     public static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     public static final String ERIC_AUTHORISED_KEY_ROLES = "ERIC-Authorised-Key-Roles";
     public static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS = "ERIC-Authorised-Token-Permissions";
-
-    public static final String API_KEY_IDENTITY_TYPE = "key";
-    public static final String INTERNAL_USER_ROLE = "*";
 }

--- a/src/main/java/uk/gov/companieshouse/api/util/security/SecurityConstants.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/SecurityConstants.java
@@ -1,0 +1,12 @@
+package uk.gov.companieshouse.api.util.security;
+
+public class SecurityConstants {
+    
+    public static final String API_KEY_IDENTITY_TYPE = "key";
+    public static final String INTERNAL_USER_ROLE = "*";
+    public static final String TOKEN_PERMISSION_REQUEST_KEY = "token_permissions";
+
+    private SecurityConstants() {
+        // Hidden constructor
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissions.java
@@ -1,41 +1,7 @@
 package uk.gov.companieshouse.api.util.security;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.lang.StringUtils;
-
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
-
-/**
- * Reads and stores the authorised ERIC token permissions from a request and
- * provides a method to check them individually
- */
-public class TokenPermissions {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(TokenPermissions.class));
-    private static final Pattern PERMISSION_LIST_PATTERN = Pattern.compile("^\\w+=\\w+(,\\w+)*( \\w+=\\w+(,\\w+)*)*$");
-
-    final String authorisedTokenPermissions;
-    Map<String, List<String>> permissions;
-
-    public TokenPermissions(HttpServletRequest request) throws InvalidTokenPermissionException{
-        authorisedTokenPermissions = AuthorisationUtil.getAuthorisedTokenPermissions(request);
-        
-        if (authorisedTokenPermissions != null
-                && !PERMISSION_LIST_PATTERN.matcher(authorisedTokenPermissions).matches()) {
-            throw new InvalidTokenPermissionException(authorisedTokenPermissions);
-        }
-    }
+@FunctionalInterface
+public interface TokenPermissions {
 
     /**
      * Check if the current key/value permission pair exists
@@ -45,38 +11,5 @@ public class TokenPermissions {
      * @return True if the key/value permission pair is present in the list of
      *         authorised token permission
      */
-    public boolean hasPermission(Permission.Key key, String value) {
-        if (permissions == null) {
-            permissions = readTokenPermissions(authorisedTokenPermissions);
-            Map<String, Object> logData = new HashMap<>();
-            logData.put("ERIC authorised token permission header", authorisedTokenPermissions);
-            logData.put("Token permissions", permissions);
-            LOGGER.debug("Parsed ERIC token permissions", logData);
-        }
-
-        return permissions.getOrDefault(key.toString(), Collections.emptyList()).contains(value);
-    }
-
-    /**
-     * The ERIC token permission is of the format: 
-     *       "key1=valueA key2=valueB key3=valueC,valueD,valueE"
-     * i.e. space separated key value pairs which themselves are separated by "=".
-     * values can also be split on a comma so we end up with an array of values per key
-     * 
-     * The example value above becomes:
-     *       "key1" : ["valueA"],
-     *       "key2" : ["valueB"],
-     *       "key3" : ["valueC", "valueD", "valueE"]
-     * 
-     * @param allPermissions
-     * @return
-     */
-    private static Map<String, List<String>> readTokenPermissions(String allPermissions) {
-        if (StringUtils.isBlank(allPermissions)) {
-            return Collections.emptyMap();
-        }
-        return Stream.of(allPermissions.trim().split(" "))
-                .map(pair -> pair.split("="))
-                .collect(Collectors.toMap(s -> s[0], s -> Arrays.asList(s[1].split(","))));
-    }
+    boolean hasPermission(Permission.Key key, String value);
 }

--- a/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissionsImpl.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/TokenPermissionsImpl.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.api.util.security;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang.StringUtils;
+
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Reads and stores the authorised ERIC token permissions from a request and
+ * provides a method to check them individually
+ */
+public class TokenPermissionsImpl implements TokenPermissions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(TokenPermissionsImpl.class));
+    private static final Pattern PERMISSION_LIST_PATTERN = Pattern.compile("^\\w+=\\w+(,\\w+)*( \\w+=\\w+(,\\w+)*)*$");
+
+    final String authorisedTokenPermissions;
+    Map<String, List<String>> permissions;
+
+    public TokenPermissionsImpl(HttpServletRequest request) throws InvalidTokenPermissionException{
+        authorisedTokenPermissions = AuthorisationUtil.getAuthorisedTokenPermissions(request);
+        
+        if (authorisedTokenPermissions != null
+                && !PERMISSION_LIST_PATTERN.matcher(authorisedTokenPermissions).matches()) {
+            throw new InvalidTokenPermissionException(authorisedTokenPermissions);
+        }
+    }
+
+
+    @Override
+    public boolean hasPermission(Permission.Key key, String value) {
+        if (permissions == null) {
+            permissions = readTokenPermissions(authorisedTokenPermissions);
+            Map<String, Object> logData = new HashMap<>();
+            logData.put("ERIC authorised token permission header", authorisedTokenPermissions);
+            logData.put("Token permissions", permissions);
+            LOGGER.debug("Parsed ERIC token permissions", logData);
+        }
+
+        return permissions.getOrDefault(key.toString(), Collections.emptyList()).contains(value);
+    }
+
+    /**
+     * The ERIC token permission is of the format: 
+     *       "key1=valueA key2=valueB key3=valueC,valueD,valueE"
+     * i.e. space separated key value pairs which themselves are separated by "=".
+     * values can also be split on a comma so we end up with an array of values per key
+     * 
+     * The example value above becomes:
+     *       "key1" : ["valueA"],
+     *       "key2" : ["valueB"],
+     *       "key3" : ["valueC", "valueD", "valueE"]
+     * 
+     * @param allPermissions
+     * @return
+     */
+    private static Map<String, List<String>> readTokenPermissions(String allPermissions) {
+        if (StringUtils.isBlank(allPermissions)) {
+            return Collections.emptyMap();
+        }
+        return Stream.of(allPermissions.trim().split(" "))
+                .map(pair -> pair.split("="))
+                .collect(Collectors.toMap(s -> s[0], s -> Arrays.asList(s[1].split(","))));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/InternalUserInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/InternalUserInterceptorTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import uk.gov.companieshouse.api.util.security.EricConstants;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(Lifecycle.PER_CLASS)
@@ -38,8 +39,8 @@ class InternalUserInterceptorTest {
     @DisplayName("Test that Handler allows a user with the correct privilege through")
     public void testUserHasCorrectPriviledges() throws IOException {
         doReturn("test user").when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY);
-        doReturn(EricConstants.API_KEY_IDENTITY_TYPE).when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY_TYPE);
-        doReturn(EricConstants.INTERNAL_USER_ROLE).when(mockRequest).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
+        doReturn(SecurityConstants.API_KEY_IDENTITY_TYPE).when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.INTERNAL_USER_ROLE).when(mockRequest).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
         assertTrue(internalUserInterceptor.preHandle(mockRequest, mockResponse, NO_HANDLER));
     }
     
@@ -61,7 +62,7 @@ class InternalUserInterceptorTest {
     @DisplayName("Test that Handler stops a request when API user does not have internal privileges")
     public void testNoInternalPriviledges() throws IOException {
         doReturn("test user").when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY);
-        doReturn(EricConstants.API_KEY_IDENTITY_TYPE).when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY_TYPE);
+        doReturn(SecurityConstants.API_KEY_IDENTITY_TYPE).when(mockRequest).getHeader(EricConstants.ERIC_IDENTITY_TYPE);
         doReturn("Yellow").when(mockRequest).getHeader(EricConstants.ERIC_AUTHORISED_KEY_ROLES);
         assertFalse(internalUserInterceptor.preHandle(mockRequest, mockResponse, NO_HANDLER));
     }

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
@@ -1,0 +1,158 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+class TokenPermissionsInterceptorTest {
+
+    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete";
+    private static final Object HANDLER = null;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Captor
+    private ArgumentCaptor<TokenPermissions> tokenPermissionsCaptor;
+
+    private TokenPermissionsInterceptor interceptor = new TokenPermissionsInterceptor();
+
+    @Test
+    @DisplayName("Test that the preHandle method sets a TokenPermissions object in the request")
+    public void preHandle() throws Exception {
+        interceptor.enableTokenPermissionAuth = true;
+        when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(AUTHORISED_TOKEN_PERMISSIONS);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+
+        verify(request).setAttribute(eq("token_permissions"), tokenPermissionsCaptor.capture());
+
+        TokenPermissions tokenPermissions = tokenPermissionsCaptor.getValue();
+
+        assertNotNull(tokenPermissions);
+        assertTrue(tokenPermissions instanceof TokenPermissionsImpl);
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_NUMBER, "00001234"));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_NUMBER, "88888888"));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.READ));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.DELETE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.DELETE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.READ));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.DELETE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.DELETE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.READ));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.CREATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.DELETE));
+    }
+
+    @Test
+    @DisplayName("Test that the preHandle method throws an exception when the token permission string is invalid")
+    public void preHandleThrowsException() throws Exception {
+        interceptor.enableTokenPermissionAuth = true;
+        when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn("invalid=");
+
+        assertThrows(InvalidTokenPermissionException.class, () -> interceptor.preHandle(request, response, HANDLER));
+    }
+
+    @Test
+    @DisplayName("Test that the preHandle method sets a TokenPermissions object in the request which gives permission to all keys apart from company number")
+    public void preHandleFeatureFlagOff() throws Exception {
+        interceptor.enableTokenPermissionAuth = false;
+        when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(AUTHORISED_TOKEN_PERMISSIONS);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+
+        verify(request).setAttribute(eq("token_permissions"), tokenPermissionsCaptor.capture());
+
+        TokenPermissions tokenPermissions = tokenPermissionsCaptor.getValue();
+
+        assertNotNull(tokenPermissions);
+        assertFalse(tokenPermissions instanceof TokenPermissionsImpl);
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_NUMBER, "00001234"));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_NUMBER, "88888888"));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_PROFILE, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_TRANSACTIONS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_AUTH_CODE, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ROA, Value.DELETE));
+    }
+
+    @Test
+    @DisplayName("Test that the postHandle method removes the TokenPermissions object from the request")
+    public void postHandle() throws Exception {
+        interceptor.enableTokenPermissionAuth = true;
+
+        interceptor.postHandle(request, response, HANDLER, null);
+
+        verify(request).setAttribute("token_permissions", null);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/util/security/AuthorisationUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/AuthorisationUtilTest.java
@@ -1,0 +1,41 @@
+package uk.gov.companieshouse.api.util.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthorisationUtilTest {
+
+    @Mock
+    HttpServletRequest request;
+
+    @Test
+    void getTokenPermissionsValidObject() {
+        TokenPermissions tokenPermissions = Mockito.mock(TokenPermissions.class);
+        when(request.getAttribute("token_permissions")).thenReturn(tokenPermissions);
+
+        Optional<TokenPermissions> result = AuthorisationUtil.getTokenPermissions(request);
+
+        assertTrue(result.isPresent());
+        assertEquals(tokenPermissions, result.get());
+    }
+    
+    @Test
+    void getTokenPermissionsMissingObject() {
+        Optional<TokenPermissions> result = AuthorisationUtil.getTokenPermissions(request);
+
+        assertFalse(result.isPresent());
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -14,7 +14,7 @@ public class TokenPermissionsTest {
     
     private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete";
 
-    TokenPermissions permissions;
+    TokenPermissionsImpl permissions;
 
     @Test
     void hasSingleCompanyNumberPermissionKeyAndValue() throws InvalidTokenPermissionException {
@@ -99,6 +99,6 @@ public class TokenPermissionsTest {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(authorisedTokenPermissins);
 
-        permissions = new TokenPermissions(request);
+        permissions = new TokenPermissionsImpl(request);
     }
 }


### PR DESCRIPTION
Create token permission interceptor. It'll create a `TokenPermission` object and add it to the request. It will eventually be read by a controller (or another interceptor) to authorise the user.

It includes a feature flag: when it is off, the stored `TokenPermission` will assume any requested permission is valid. This happens for all the permission keys apart from `company_number` which will be checked.

Also move non-eric constants to separate constant file