### PR TITLE
Check for invalid type

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/AuthorisationUtil.java
@@ -5,8 +5,10 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 
 public final class AuthorisationUtil {
-    private AuthorisationUtil() {}
-    
+    private AuthorisationUtil() {
+        // Hidden constructor for utility class
+    }
+
     public static String getAuthorisedIdentity(HttpServletRequest request) {
         return RequestUtils.getRequestHeader(request, EricConstants.ERIC_IDENTITY);
     }
@@ -14,20 +16,21 @@ public final class AuthorisationUtil {
     public static String getAuthorisedIdentityType(HttpServletRequest request) {
         return RequestUtils.getRequestHeader(request, EricConstants.ERIC_IDENTITY_TYPE);
     }
-    
+
     public static String getAuthorisedKeyRoles(HttpServletRequest request) {
         return RequestUtils.getRequestHeader(request, EricConstants.ERIC_AUTHORISED_KEY_ROLES);
     }
-    
+
     protected static String getAuthorisedTokenPermissions(HttpServletRequest request) {
         return RequestUtils.getRequestHeader(request, EricConstants.ERIC_AUTHORISED_TOKEN_PERMISSIONS);
     }
-    
+
     public static boolean hasInternalUserRole(HttpServletRequest request) {
         return SecurityConstants.INTERNAL_USER_ROLE.equals(getAuthorisedKeyRoles(request));
     }
-    
+
     public static Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
-        return Optional.ofNullable((TokenPermissions) request.getAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY));
+        Object value = request.getAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY);
+        return Optional.ofNullable(value instanceof TokenPermissions ? (TokenPermissions) value : null);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/api/util/security/AuthorisationUtilTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/AuthorisationUtilTest.java
@@ -31,7 +31,16 @@ public class AuthorisationUtilTest {
         assertTrue(result.isPresent());
         assertEquals(tokenPermissions, result.get());
     }
-    
+
+    @Test
+    void getTokenPermissionsInvalidObject() {
+        when(request.getAttribute("token_permissions")).thenReturn(new Object());
+
+        Optional<TokenPermissions> result = AuthorisationUtil.getTokenPermissions(request);
+
+        assertFalse(result.isPresent());
+    }
+
     @Test
     void getTokenPermissionsMissingObject() {
         Optional<TokenPermissions> result = AuthorisationUtil.getTokenPermissions(request);


### PR DESCRIPTION
Check the type of the object stored in the request as `token_permissions` and  return an empty optional when invalid (not a `TokenPermissions`) rather than throwing an exception