### PR TITLE
feature/S4-73 - Add Company Status Permission Key

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
@@ -28,6 +28,10 @@ public class Permission {
          */
         COMPANY_NUMBER("company_number"),
         /**
+         * Key for the company status permissions
+         */
+        COMPANY_STATUS("company_status"),
+        /**
          * Key for the company transactions permissions
          */
         COMPANY_TRANSACTIONS("company_transactions"),

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
@@ -136,6 +136,10 @@ class TokenPermissionsInterceptorTest {
         assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE));
         assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.CREATE));
         assertTrue(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.UPDATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.DELETE));
         assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
         assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
         assertTrue(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptorTest.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
 @TestInstance(Lifecycle.PER_CLASS)
 class TokenPermissionsInterceptorTest {
 
-    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete";
+    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete company_status=read,update,delete";
     private static final Object HANDLER = null;
 
     @Mock
@@ -81,6 +81,10 @@ class TokenPermissionsInterceptorTest {
         assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.UPDATE));
         assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.CREATE));
         assertFalse(tokenPermissions.hasPermission(Key.COMPANY_ACCOUNTS, Value.DELETE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.READ));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.UPDATE));
+        assertFalse(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.CREATE));
+        assertTrue(tokenPermissions.hasPermission(Key.COMPANY_STATUS, Value.DELETE));
         assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.READ));
         assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.UPDATE));
         assertFalse(tokenPermissions.hasPermission(Key.USER_APPLICATIONS, Value.CREATE));

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mockito;
 
 public class TokenPermissionsTest {
     
-    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 company_transactions=read user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete";
+    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 company_transactions=read user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete company_status=read,update,delete";
 
     TokenPermissionsImpl permissions;
 
@@ -58,6 +58,11 @@ public class TokenPermissionsTest {
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
+
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.CREATE));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.READ));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.UPDATE));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.DELETE));
 
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.READ));


### PR DESCRIPTION
A new `company_status` permission is being added for the new dissolutions service, as outlined here - https://companieshouse.atlassian.net/wiki/spaces/ER/pages/1772617909/Authentication