### PR TITLE
CRUD permission interceptor

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptor.java
@@ -7,7 +7,9 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
@@ -20,28 +22,43 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 /**
  * Checks the request contains the relevant token permission value based on the
  * http method 
- * Prerequisite: the {@link TokenPermissionsInterceptor} must have
- * run previously so that a {@link TokenPermissions} object is stored in the request
+ * It will try to find a {@link TokenPermissions} object in the
+ * request or create one and store it in the request if not
  */
 public class CRUDAuthenticationInterceptor extends HandlerInterceptorAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(CRUDAuthenticationInterceptor.class));
-    
+
+    @Value("${ENABLE_TOKEN_PERMISSION_AUTH:#{false}}")
+    boolean enableTokenPermissionAuth;
+
     private final Permission.Key permissionKey;
-    
+
     public CRUDAuthenticationInterceptor(Permission.Key permissionKey) {
         this.permissionKey = permissionKey;
     }
-    
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
-            throws InvalidTokenPermissionException {
-        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
-        final TokenPermissions tokenPermissions = getTokenPermissions(request)
-                .orElseThrow(() -> new IllegalStateException("TokenPermissions object not present in request"));
 
-        String permissionValue = getValue(request);
-        boolean authorised = tokenPermissions.hasPermission(permissionKey, permissionValue);
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws InvalidTokenPermissionException{
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final TokenPermissions tokenPermissions = getTokenPermissionsFromRequest(request)
+                .orElseGet(() -> {
+                    try {
+                        TokenPermissions tp = InterceptorHelper.readTokenPermissions(request,
+                                enableTokenPermissionAuth);
+                        InterceptorHelper.storeTokenPermissionsInRequest(tp, request);
+                        Map<String, Object> loggedData = new HashMap<>();
+                        loggedData.put("Feature flag ENABLE_TOKEN_PERMISSION_AUTH", enableTokenPermissionAuth);
+                        LOGGER.debug("Create TokenPermissions and store it in request", loggedData);
+                        return tp;
+                    } catch (InvalidTokenPermissionException e) {
+                        // Wrap into a runtime exception to fit the Supplier interface
+                        throw new IllegalStateException(e);
+                    }
+                });
+
+        final String permissionValue = getValue(request);
+        final boolean authorised = tokenPermissions.hasPermission(permissionKey, permissionValue);
 
         final Map<String, Object> debugMap = new HashMap<>();
         debugMap.put("request_method", request.getMethod());
@@ -52,11 +69,18 @@ public class CRUDAuthenticationInterceptor extends HandlerInterceptorAdapter {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
 
-        LOGGER.debugRequest(request, "CRUDAuthenticationInterceptor ran", debugMap);
+        LOGGER.debugRequest(request, "CRUDAuthenticationInterceptor handled request", debugMap);
         return authorised;
     }
 
-    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+            ModelAndView modelAndView) throws Exception {
+        // cleanup request to ensure it is never leaked into another request
+        InterceptorHelper.storeTokenPermissionsInRequest(null, request);
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissionsFromRequest(HttpServletRequest request) {
         return AuthorisationUtil.getTokenPermissions(request);
     }
 

--- a/src/main/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptor.java
@@ -1,0 +1,77 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+
+import uk.gov.companieshouse.api.util.security.AuthorisationUtil;
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+/**
+ * Checks the request contains the relevant token permission value based on the
+ * http method 
+ * Prerequisite: the {@link TokenPermissionsInterceptor} must have
+ * run previously so that a {@link TokenPermissions} object is stored in the request
+ */
+public class CRUDAuthenticationInterceptor extends HandlerInterceptorAdapter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(String.valueOf(CRUDAuthenticationInterceptor.class));
+    
+    private final Permission.Key permissionKey;
+    
+    public CRUDAuthenticationInterceptor(Permission.Key permissionKey) {
+        this.permissionKey = permissionKey;
+    }
+    
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws InvalidTokenPermissionException {
+        // TokenPermissions should have been set up in the request by TokenPermissionsInterceptor
+        final TokenPermissions tokenPermissions = getTokenPermissions(request)
+                .orElseThrow(() -> new IllegalStateException("TokenPermissions object not present in request"));
+
+        String permissionValue = getValue(request);
+        boolean authorised = tokenPermissions.hasPermission(permissionKey, permissionValue);
+
+        final Map<String, Object> debugMap = new HashMap<>();
+        debugMap.put("request_method", request.getMethod());
+        debugMap.put("authorised", authorised);
+        debugMap.put("expected_permission", permissionKey + "=" + permissionValue);
+
+        if (!authorised) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        }
+
+        LOGGER.debugRequest(request, "CRUDAuthenticationInterceptor ran", debugMap);
+        return authorised;
+    }
+
+    protected Optional<TokenPermissions> getTokenPermissions(HttpServletRequest request) {
+        return AuthorisationUtil.getTokenPermissions(request);
+    }
+
+    private String getValue(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (HttpMethod.PUT.matches(method) || HttpMethod.PATCH.matches(method)) {
+            return Permission.Value.UPDATE;
+        }
+        if (HttpMethod.POST.matches(method)) {
+            return Permission.Value.CREATE;
+        }
+        if (HttpMethod.DELETE.matches(method)) {
+            return Permission.Value.DELETE;
+        }
+        return Permission.Value.READ;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/api/interceptor/InterceptorHelper.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/InterceptorHelper.java
@@ -1,0 +1,60 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.api.util.security.SecurityConstants;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
+
+class InterceptorHelper {
+
+    private InterceptorHelper() {
+        // Private constructor for utility class
+    }
+
+    /**
+     * Parse the token permissions object from the request and return a
+     * {@link TokenPermissions} object
+     * 
+     * @param request                   The HTTP request
+     * @param enableTokenPermissionAuth Feature flag: when true, it will create a
+     *                                  token permissions object which will check
+     *                                  the relevant eric header to authorise via
+     *                                  token permissions. If false, the object
+     *                                  stored in the session will only check the
+     *                                  header for the company number permission and
+     *                                  authorise any other
+     * @return A {@link TokenPermissions} object containing the permissions for the
+     *         request
+     * @throws InvalidTokenPermissionException If there is a problem parsing the
+     *                                         request
+     */
+    static TokenPermissions readTokenPermissions(HttpServletRequest request, boolean enableTokenPermissionAuth)
+            throws InvalidTokenPermissionException {
+        final TokenPermissions tokenPermissions = new TokenPermissionsImpl(request);
+        if (enableTokenPermissionAuth) {
+            return tokenPermissions;
+        } else {
+            // We behave as if we had all permissions except for the company number
+            return (k, v) -> {
+                if (k.equals(Permission.Key.COMPANY_NUMBER)) {
+                    return tokenPermissions.hasPermission(k, v);
+                } else {
+                    return true;
+                }
+            };
+        }
+    }
+
+    /**
+     * Store the given TokenPermissions object in the given request
+     * 
+     * @param tokenPermissions It can be null if we want to remove the existing one
+     * @param request
+     */
+    static void storeTokenPermissionsInRequest(TokenPermissions tokenPermissions, HttpServletRequest request) {
+        request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, tokenPermissions);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/api/interceptor/TokenPermissionsInterceptor.java
@@ -12,10 +12,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
-import uk.gov.companieshouse.api.util.security.Permission;
-import uk.gov.companieshouse.api.util.security.SecurityConstants;
 import uk.gov.companieshouse.api.util.security.TokenPermissions;
-import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -30,27 +27,16 @@ public class TokenPermissionsInterceptor extends HandlerInterceptorAdapter {
 
     @Value("${ENABLE_TOKEN_PERMISSION_AUTH:#{false}}")
     boolean enableTokenPermissionAuth;
-    
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws InvalidTokenPermissionException {
         Map<String, Object> loggedData = new HashMap<>();
         loggedData.put("Feature flag ENABLE_TOKEN_PERMISSION_AUTH", enableTokenPermissionAuth);
         LOGGER.debug("Create TokenPermissions and store it in request", loggedData);
-        final TokenPermissions tokenPermissions = new TokenPermissionsImpl(request);
-        if (enableTokenPermissionAuth) {
-            request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, tokenPermissions);
-        } else {
-            // We behave as if we had all permissions except for the company number
-            TokenPermissions tp = (k, v) -> {
-                if (k.equals(Permission.Key.COMPANY_NUMBER)) {
-                    return tokenPermissions.hasPermission(k, v);
-                } else {
-                    return true;
-                }
-            };
-            request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, tp);
-        }
+
+        TokenPermissions tokenPermissions = InterceptorHelper.readTokenPermissions(request, enableTokenPermissionAuth);
+        InterceptorHelper.storeTokenPermissionsInRequest(tokenPermissions, request);
         return true;
     }
 
@@ -58,30 +44,7 @@ public class TokenPermissionsInterceptor extends HandlerInterceptorAdapter {
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
             ModelAndView modelAndView) throws Exception {
         // cleanup request to ensure it is never leaked into another request
-        request.setAttribute(SecurityConstants.TOKEN_PERMISSION_REQUEST_KEY, null);
+        InterceptorHelper.storeTokenPermissionsInRequest(null, request);
     }
 
-    /**
-     * Set the feature flag: if on (true) this interceptor will create a token
-     * permissions object which will check the relevant eric header to authorise via
-     * token permissions. If off (false), the object stored in the session will only
-     * check the header for the company number permission and authorise any other
-     * 
-     * @param enable
-     */
-    public void setEnableTokenPermission(boolean enable) {
-        enableTokenPermissionAuth = enable;
-    }
-    
-    /**
-     * Read the feature flag: if on (true) this interceptor will create a token
-     * permissions object which will check the relevant eric header to authorise via
-     * token permissions. If off (false), the object stored in the session will only
-     * check the header for the company number permission and authorise any other
-     * 
-     * @return True if the feature flag is on. False if it is off
-     */
-    public boolean isEnableTokenPermission() {
-        return enableTokenPermissionAuth;
-    }
 }

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -41,7 +42,7 @@ public class CRUDAuthenticationInterceptorTest {
     private final Permission.Key permissionKey = Permission.Key.USER_PROFILE;
 
     @Spy
-    private CRUDAuthenticationInterceptor interceptor = new CRUDAuthenticationInterceptor(permissionKey);
+    private CRUDAuthenticationInterceptor interceptor = new CRUDAuthenticationInterceptor(permissionKey, "IGNORED", "OTHER");
 
     @Mock
     private HttpServletRequest request;
@@ -339,11 +340,32 @@ public class CRUDAuthenticationInterceptorTest {
     }
 
     @Test
+    @DisplayName("Test that the preHandle method does nothing when the HTTP method is ignored")
+    void preHandleIgnoreRequest() throws Exception {
+        when(request.getMethod()).thenReturn("OTHER");
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+
+        verifyNoMoreInteractions(request);
+    }
+
+    @Test
     @DisplayName("Test that the postHandle method removes the TokenPermissions object from the request")
     void postHandle() throws Exception {
         interceptor.postHandle(request, response, HANDLER, null);
 
         verify(request).setAttribute("token_permissions", null);
+    }
+
+    @Test
+    @DisplayName("Test that the postHandle method does nothing when the HTTP method is ignored")
+    void postHandleIgnoredMethod() throws Exception {
+        when(request.getMethod()).thenReturn("IGNORED");
+
+        interceptor.postHandle(request, response, HANDLER, null);
+
+        verify(interceptor, never()).getTokenPermissionsFromRequest(request);
+        verifyNoMoreInteractions(request);
     }
 
     private void setupTokenPermissions() {

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/CRUDAuthenticationInterceptorTest.java
@@ -1,0 +1,292 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.Permission;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+
+@ExtendWith(MockitoExtension.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public class CRUDAuthenticationInterceptorTest {
+    private static final Object HANDLER = null;
+
+    private final Permission.Key permissionKey = Permission.Key.USER_PROFILE;
+
+    @Spy
+    private CRUDAuthenticationInterceptor interceptor = new CRUDAuthenticationInterceptor(permissionKey);
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private TokenPermissions tokenPermissions;
+
+    @Test
+    @DisplayName("Test preHandle when TokenPermissions is not present in request")
+    void preHandleMissingTokenPermissions() throws Exception {
+        assertThrows(IllegalStateException.class, () -> interceptor.preHandle(request, response, HANDLER));
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid POST request")
+    void preHandleAuthorisedPost() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("POST");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.CREATE)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid POST request")
+    void preHandleUnauthorisedPost() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("POST");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.CREATE)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid GET request")
+    void preHandleAuthorisedGet() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("GET");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid GET request")
+    void preHandleUnauthorisedGet() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("GET");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid PUT request")
+    void preHandleAuthorisedPut() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("PUT");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.UPDATE)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid PUT request")
+    void preHandleUnauthorisedPut() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("PUT");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.UPDATE)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid DELETE request")
+    void preHandleAuthorisedDelete() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("DELETE");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.DELETE)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid DELETE request")
+    void preHandleUnauthorisedDelete() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("DELETE");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.DELETE)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid PATCH request")
+    void preHandleAuthorisedPatch() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("PATCH");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.UPDATE)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid PATCH request")
+    void preHandleUnauthorisedPatch() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("PATCH");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.UPDATE)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid HEAD request")
+    void preHandleAuthorisedHead() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("HEAD");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid HEAD request")
+    void preHandleUnauthorisedHead() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("HEAD");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid CONNECT request")
+    void preHandleAuthorisedConnect() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("CONNECT");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid CONNECT request")
+    void preHandleUnauthorisedConnect() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("CONNECT");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid OPTIONS request")
+    void preHandleAuthorisedOptions() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("OPTIONS");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid OPTIONS request")
+    void preHandleUnauthorisedOptions() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("OPTIONS");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with a valid TRACE request")
+    void preHandleAuthorisedTrace() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("TRACE");
+        final boolean authorised = true;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertTrue(interceptor.preHandle(request, response, HANDLER));
+        verifyNoInteractions(response);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Tests the interceptor with an invalid TRACE request")
+    void preHandleUnauthorisedTrace() throws InvalidTokenPermissionException {
+        setupTokenPermissions();
+        when(request.getMethod()).thenReturn("TRACE");
+        final boolean authorised = false;
+        when(tokenPermissions.hasPermission(permissionKey, Value.READ)).thenReturn(authorised);
+
+        assertFalse(interceptor.preHandle(request, response, HANDLER));
+        verify(response).setStatus(401);
+        verifyNoMoreInteractions(tokenPermissions);
+    }
+    private void setupTokenPermissions() {
+        doReturn(Optional.of(tokenPermissions)).when(interceptor).getTokenPermissions(request);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/api/interceptor/InterceptorHelperTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/interceptor/InterceptorHelperTest.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.api.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import uk.gov.companieshouse.api.util.security.InvalidTokenPermissionException;
+import uk.gov.companieshouse.api.util.security.TokenPermissions;
+import uk.gov.companieshouse.api.util.security.TokenPermissionsImpl;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
+
+@ExtendWith(MockitoExtension.class)
+public class InterceptorHelperTest {
+
+    @Test
+    @DisplayName("Test readTokenPermissions")
+    void readTokenPermissions() throws InvalidTokenPermissionException {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        final boolean featureFlag = true;
+
+        when(request.getHeader("ERIC-Authorised-Token-Permissions"))
+                .thenReturn("company_number=00001234 user_profile=read");
+
+        TokenPermissions tp = InterceptorHelper.readTokenPermissions(request, featureFlag);
+
+        assertNotNull(tp);
+        assertTrue(tp instanceof TokenPermissionsImpl);
+        assertTrue(tp.hasPermission(Key.COMPANY_NUMBER, "00001234"));
+        assertFalse(tp.hasPermission(Key.COMPANY_NUMBER, "88888888"));
+        assertTrue(tp.hasPermission(Key.USER_PROFILE, Value.READ));
+        assertFalse(tp.hasPermission(Key.USER_PROFILE, Value.UPDATE));
+        assertFalse(tp.hasPermission(Key.USER_PROFILE, Value.CREATE));
+        assertFalse(tp.hasPermission(Key.USER_PROFILE, Value.DELETE));
+    }
+
+    @Test
+    @DisplayName("Test readTokenPermissions when feature flag is off")
+    void readTokenPermissionsFlagOff() throws InvalidTokenPermissionException {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        final boolean featureFlag = false;
+
+        when(request.getHeader("ERIC-Authorised-Token-Permissions"))
+                .thenReturn("company_number=00001234 user_profile=read");
+
+        TokenPermissions tp = InterceptorHelper.readTokenPermissions(request, featureFlag);
+
+        assertNotNull(tp);
+        // It is a lambda implementation when the flag is off
+        assertFalse(tp instanceof TokenPermissionsImpl);
+        assertTrue(tp.hasPermission(Key.COMPANY_NUMBER, "00001234"));
+        assertFalse(tp.hasPermission(Key.COMPANY_NUMBER, "88888888"));
+        assertTrue(tp.hasPermission(Key.USER_PROFILE, Value.READ));
+        assertTrue(tp.hasPermission(Key.USER_PROFILE, Value.UPDATE));
+        assertTrue(tp.hasPermission(Key.USER_PROFILE, Value.CREATE));
+        assertTrue(tp.hasPermission(Key.USER_PROFILE, Value.DELETE));
+    }
+
+    @Test
+    @DisplayName("Test storeTokenPermissionsInRequest with valid object")
+    void storeTokenPermissionsInRequest() {
+        TokenPermissions tokenPermissions = Mockito.mock(TokenPermissions.class);
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        InterceptorHelper.storeTokenPermissionsInRequest(tokenPermissions, request);
+
+        verify(request).setAttribute("token_permissions", tokenPermissions);
+        verifyNoMoreInteractions(request);
+        verifyNoInteractions(tokenPermissions);
+    }
+
+    @Test
+    @DisplayName("Test storeTokenPermissionsInRequest with null")
+    void storeTokenPermissionsInRequestNull() {
+        TokenPermissions tokenPermissions = null;
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        InterceptorHelper.storeTokenPermissionsInRequest(tokenPermissions, request);
+
+        verify(request).setAttribute("token_permissions", tokenPermissions);
+        verifyNoMoreInteractions(request);
+    }
+}


### PR DESCRIPTION
Create new interceptor to check CRUD permissions based on the HTTP method
It will use the `TokenPermissions` from the request if present. Otherwise it will parse the ERIC header and store it in the request for future use (maybe by another instance of this interceptor)
Refactor the `TokenPermissionInterceptor` to extract the common logic to a helper.

Resolves FA-960