### PR TITLE
Revert pom changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 
         <!-- JDK -->
         <source-level>1.8</source-level>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,8 @@
         <source-level>1.8</source-level>
         <target-level>1.8</target-level>
         <!-- Spring -->
-        <spring-boot-dependencies.version>2.3.7.RELEASE</spring-boot-dependencies.version>
-        <spring-test.version>5.1.3.RELEASE</spring-test.version>
-        <spring-boot-maven-plugin.version>2.3.7.RELEASE</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>2.2.0.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Revert some pom changes introduced in #23
- Downgrade Spring Boot to previous tested version
- Remove unnecessary overriding of a property defined in parent pom
- Changes in spring test dependency to exclude JUnit 4 and make it optional