### PR TITLE
Add new permission for psc discrepancy reports

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
@@ -58,7 +58,11 @@ public class Permission {
         /**
          * Key for promise to file permissions
          */
-        PROMISE_TO_FILE("company_promise_to_file");
+        PROMISE_TO_FILE("company_promise_to_file"),
+        /**
+         * Key for psc discrepancy reports permissions
+         */
+        PSC_DISCREPANCY_REPORT("psc_discrepancy_report");
 
         private String stringValue;
 

--- a/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
@@ -62,7 +62,7 @@ public class Permission {
         /**
          * Key for psc discrepancy reports permissions
          */
-        PSC_DISCREPANCY_REPORT("psc_discrepancy_report");
+        USER_PSC_DISCREPANCY_REPORT("user_psc_discrepancy_report");
 
         private String stringValue;
 


### PR DESCRIPTION
- add new permission in the key enum in Permission.java for psc discrepancy reports

This pr is part of a ticket to add authentication to the psi-discrepancies api: https://companieshouse.atlassian.net/browse/FAML-635