### PR TITLE
DACT-145 : add token permissions for officer-filing-api

### DIFF
--- a/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
+++ b/src/main/java/uk/gov/companieshouse/api/util/security/Permission.java
@@ -70,7 +70,11 @@ public class Permission {
         /**
          * Key for overseas entity permissions
          */
-        COMPANY_INCORPORATION("company_incorporation");
+        COMPANY_INCORPORATION("company_incorporation"),
+        /**
+         * Key for company officers permissions
+         */
+        COMPANY_OFFICERS("company_officers");
 
         private String stringValue;
 
@@ -93,6 +97,10 @@ public class Permission {
          * Value for resource reading permissions
          */
         public static final String READ = "read";
+        /**
+         * Value for resource accessing protected data
+         */
+        public static final String READ_PROTECTED = "readprotected";
         /**
          * Value for resource updating permissions
          */

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -40,42 +40,69 @@ class TokenPermissionsTest {
     }
 
     @Test
-    void hasPermissionKeysAndValues() throws InvalidTokenPermissionException {
+    void hasCompanyNumberPermissionKeysAndValues() throws InvalidTokenPermissionException {
         setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
-
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_NUMBER, "00001234"));
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_NUMBER, "43210000"));
+    }
 
+    @Test
+    void hasUserProfilePermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.USER_PROFILE, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.USER_PROFILE, Permission.Value.READ));
         assertFalse(permissions.hasPermission(Permission.Key.USER_PROFILE, Permission.Value.UPDATE));
         assertFalse(permissions.hasPermission(Permission.Key.USER_PROFILE, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasUserTransactionsPermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertTrue(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.UPDATE));
         assertFalse(permissions.hasPermission(Permission.Key.USER_TRANSACTIONS, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasCompanyAuthCodePermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.UPDATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_AUTH_CODE, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasCompanyStatusPermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.UPDATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_STATUS, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasCompanyTransactionsPermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.CREATE));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.READ));
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.UPDATE));
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_TRANSACTIONS, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasPromiseToFilesPermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertFalse(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.CREATE));
         assertFalse(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.UPDATE));
         assertFalse(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.DELETE));
+    }
 
+    @Test
+    void hasCompanyOfficersPermissionKeysAndValues() throws InvalidTokenPermissionException {
+        setupPermissionHeader(AUTHORISED_TOKEN_PERMISSIONS);
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Value.READ_PROTECTED));
         assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Permission.Value.DELETE));
         assertFalse(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Permission.Value.READ));

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -9,7 +9,6 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import uk.gov.companieshouse.api.util.security.Permission.Key;
 import uk.gov.companieshouse.api.util.security.Permission.Value;
 
 class TokenPermissionsTest {

--- a/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
+++ b/src/test/java/uk/gov/companieshouse/api/util/security/TokenPermissionsTest.java
@@ -9,10 +9,12 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import uk.gov.companieshouse.api.util.security.Permission.Key;
+import uk.gov.companieshouse.api.util.security.Permission.Value;
 
 class TokenPermissionsTest {
 
-    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 company_transactions=read user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete company_status=read,update,delete company_promise_to_file=update";
+    private static final String AUTHORISED_TOKEN_PERMISSIONS = "company_number=00001234 company_transactions=read user_profile=read user_transactions=read,create,update company_auth_code=read,update,delete company_status=read,update,delete company_promise_to_file=update company_officers=delete,readprotected,update,create";
 
     TokenPermissionsImpl permissions;
 
@@ -73,6 +75,12 @@ class TokenPermissionsTest {
         assertFalse(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.READ));
         assertTrue(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.UPDATE));
         assertFalse(permissions.hasPermission(Permission.Key.PROMISE_TO_FILE, Permission.Value.DELETE));
+
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Value.READ_PROTECTED));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Permission.Value.DELETE));
+        assertFalse(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Permission.Value.READ));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Value.UPDATE));
+        assertTrue(permissions.hasPermission(Permission.Key.COMPANY_OFFICERS, Value.CREATE));
     }
 
     @Test


### PR DESCRIPTION
Added token permissions needed for officer-filing-api
https://companieshouse.atlassian.net/browse/DACT-145