### PR TITLE
[2696] Upgrade dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,9 @@
         <gson.version>2.13.1</gson.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-        <api-sdk-java.version>6.3.4</api-sdk-java.version>
-        <structured-logging.version>3.0.36</structured-logging.version>
-        <api-sdk-manager-java-library.version>3.0.8</api-sdk-manager-java-library.version>
+        <api-sdk-java.version>6.4.1</api-sdk-java.version>
+        <structured-logging.version>3.0.37</structured-logging.version>
+        <api-sdk-manager-java-library.version>3.0.10</api-sdk-manager-java-library.version>
 
         <!-- Maven -->
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
@@ -32,8 +32,11 @@
         <source-level>21</source-level>
         <target-level>21</target-level>
         <!-- Spring -->
-        <spring-boot-dependencies.version>3.1.3</spring-boot-dependencies.version>
-        <spring-boot-maven-plugin.version>3.1.3</spring-boot-maven-plugin.version>
+        <spring-boot-dependencies.version>3.4.8</spring-boot-dependencies.version>
+        <spring-boot-maven-plugin.version>3.4.8</spring-boot-maven-plugin.version>
+        <spring-core.version>6.2.9</spring-core.version>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+        <commons-collections4.version>4.4</commons-collections4.version>
     </properties>
 
     <dependencyManagement>
@@ -59,7 +62,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>6.0.9</version>
+            <version>${spring-core.version}</version>
         </dependency>
 
         <dependency>
@@ -80,7 +83,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>6.0.0</version>
+            <version>${jakarta.servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -118,7 +121,7 @@
         <dependency>
             <artifactId>commons-collections4</artifactId>
             <groupId>org.apache.commons</groupId>
-            <version>4.4</version>
+            <version>${commons-collections4.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
 - Replaced hard-coded versions in dependencies with property references
 - CVEs resolved CVE-2024-11407,CVE-2023-35116,CVE-2023-6378,CVE-2022-1471,CVE-2023-34055,CVE-2024-22259,CVE-2024-38809,CVE-2024-38816,CVE-2024-50379
 - Bumped the following dependencies
   - api-sdk-java version to 6.4.1
   - spring-boot-maven-plugin version to 3.4.8
   - spring-boot-dependencies version to 3.4.8
   - spring-core version to 6.2.9
   - structured-logging version to 3.0.37
   - api-sdk-manager-java-library version to 3.0.10